### PR TITLE
feat: Add git commands and conventional commits

### DIFF
--- a/src/content/standards/prs.mdx
+++ b/src/content/standards/prs.mdx
@@ -68,22 +68,22 @@ Explain how you tested it
 
 ## Basic Git Commands
 
-- **```git status```** - show modified files in working directory   
-- **```git add [-A] [file]```** - add a file to next commit (aka stage)  
-  &emsp;&minus;&nbsp; optional ```-A``` adds all modified files
-- **```git restore --staged [file]```** - unstage a file so it is not included in commit  
-- **```git commit -m "[commit message]"```** - commit staged content  
+- **`git status`** - show modified files in working directory   
+- **`git add [-A] [file]`** - add a file to next commit (aka stage)  
+  &emsp;&minus;&nbsp; optional `-A` adds all modified files
+- **`git restore --staged [file]`** - unstage a file so it is not included in commit  
+- **`git commit -m "[commit message]"`** - commit staged content  
   
-- **```git branch```** - list branches, denoting current branch with *  
-- **```git checkout [-b] [branch-name]```** - switch working branch to branch-name  
-  &emsp;&minus;&nbsp; optional ```-b``` creates a new branch called branch-name
+- **`git branch`** - list branches, denoting current branch with *  
+- **`git checkout [-b] [branch-name]`** - switch working branch to branch-name  
+  &emsp;&minus;&nbsp; optional `-b` creates a new branch called branch-name
 
-- **```git push [origin] [branch-name]```** - push local commits to remote repository  
-- **```git fetch```** - fetch commits from remote repository without changing local working directory
-- **```git merge [branch-name]```** - merge branch-name into current branch
-- **```git rebase [branch-name]```** - apply and add commits from current branch to branch-name
-- **```git pull```** - fetch and merge any commits from remote repository  
-- **```git log```** - show commit history for active branch  
+- **`git push [origin] [branch-name]`** - push local commits to remote repository  
+- **`git fetch`** - fetch commits from remote repository without changing local working directory
+- **`git merge [branch-name]`** - merge branch-name into current branch
+- **`git rebase [branch-name]`** - apply and add commits from current branch to branch-name
+- **`git pull`** - fetch and merge any commits from remote repository  
+- **`git log`** - show commit history for active branch  
 
 ## Conventional Commit Standards
 
@@ -97,17 +97,17 @@ Basic Commit Message Structure:
 [optional footer(s)]
 ```
 
-There should be blank lines in between the type, body, and footer. Footer tokens must be connected with ```-``` if more than one word, with ```BREAKING CHANGE``` being an exception.
+There should be blank lines in between the type, body, and footer. Footer tokens must be connected with `-` if more than one word, with `BREAKING CHANGE` being an exception.
 
-**BREAKING CHANGE:** a commit that has a footer **```BREAKING CHANGE:```**, or appends a **```!```** after the type/scope, introduces a breaking API change  
+**BREAKING CHANGE:** a commit that has a footer **`BREAKING CHANGE:`**, or appends a **`!`** after the type/scope, introduces a breaking API change  
 
 **Types:**
-- **```fix:```** patch a bug
-- **```feat:```** introduce a new feature
-- **```chore:```** update grunt tasks
-- **```docs:```** change documentation
-- **```perf:```** performance improvement
-- **```style:```** change formatting, add missing semicolons, etc.
-- **```refactor:```** refactor production code (e.g. rename a variable)
-- **```test:```** add missing tests or change existing tests
-- **```build:```** update build configuration, development tools, etc.
+- **`fix:`** patch a bug
+- **`feat:`** introduce a new feature
+- **`chore:`** update grunt tasks
+- **`docs:`** change documentation
+- **`perf:`** performance improvement
+- **`style:`** change formatting, add missing semicolons, etc.
+- **`refactor:`** refactor production code (e.g. rename a variable)
+- **`test:`** add missing tests or change existing tests
+- **`build:`** update build configuration, development tools, etc.

--- a/src/content/standards/prs.mdx
+++ b/src/content/standards/prs.mdx
@@ -70,16 +70,44 @@ Explain how you tested it
 
 - **```git status```** - show modified files in working directory   
 - **```git add [-A] [file]```** - add a file to next commit (aka stage)  
-  &emsp;&minus;&nbsp; optional **```-A```** adds all modified files
+  &emsp;&minus;&nbsp; optional ```-A``` adds all modified files
 - **```git restore --staged [file]```** - unstage a file so it is not included in commit  
 - **```git commit -m "[commit message]"```** - commit staged content  
   
 - **```git branch```** - list branches, denoting current branch with *  
 - **```git checkout [-b] [branch-name]```** - switch working branch to branch-name  
-  &emsp;&minus;&nbsp; optional **```-b```** creates a new branch called branch-name
+  &emsp;&minus;&nbsp; optional ```-b``` creates a new branch called branch-name
 
 - **```git push [origin] [branch-name]```** - push local commits to remote repository  
 - **```git fetch```** - fetch commits from remote repository without changing local working directory
 - **```git merge [branch-name]```** - merge branch-name into current branch
+- **```git rebase [branch-name]```** - apply and add commits from current branch to branch-name
 - **```git pull```** - fetch and merge any commits from remote repository  
 - **```git log```** - show commit history for active branch  
+
+## Conventional Commit Standards
+
+Basic Commit Message Structure:
+
+```md
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+There should be blank lines in between the type, body, and footer. Footer tokens must be connected with ```-``` if more than one word, with ```BREAKING CHANGE``` being an exception.
+
+**BREAKING CHANGE:** a commit that has a footer **```BREAKING CHANGE:```**, or appends a **```!```** after the type/scope, introduces a breaking API change  
+
+**Types:**
+- **```fix:```** patch a bug
+- **```feat:```** introduce a new feature
+- **```chore:```** update grunt tasks
+- **```docs:```** change documentation
+- **```perf:```** performance improvement
+- **```style:```** change formatting, add missing semicolons, etc.
+- **```refactor:```** refactor production code (e.g. rename a variable)
+- **```test:```** add missing tests or change existing tests
+- **```build:```** update build configuration, development tools, etc.

--- a/src/content/standards/prs.mdx
+++ b/src/content/standards/prs.mdx
@@ -56,12 +56,12 @@ Explain how you tested it
 
 ## Author checklist (before requesting review)
 
-[] Title and description follow the template (with links)
-[] Scope is focused; unrelated cleanup is split or ticketed
-[] Tests added/updated; CI is green locally or in draft CI
-[] Docs/runbooks/config examples updated if behavior changed
-[] Screenshots/recordings/logs attached where applicable
-[] Does it follow all the principles? (E.g., DRY, YAGNI, KISS)
-[] Do the files you touched have dead or commented out code you need to remove?
-[] Do the files you touched need to have small refactors?
-[] Is your PR less than 300 lines?
+- [ ] Title and description follow the template (with links)
+- [ ] Scope is focused; unrelated cleanup is split or ticketed
+- [ ] Tests added/updated; CI is green locally or in draft CI
+- [ ] Docs/runbooks/config examples updated if behavior changed
+- [ ] Screenshots/recordings/logs attached where applicable
+- [ ] Does it follow all the principles? (E.g., DRY, YAGNI, KISS)
+- [ ] Do the files you touched have dead or commented out code you need to remove?
+- [ ] Do the files you touched need to have small refactors?
+- [ ] Is your PR less than 300 lines?

--- a/src/content/standards/prs.mdx
+++ b/src/content/standards/prs.mdx
@@ -65,3 +65,21 @@ Explain how you tested it
 - [ ] Do the files you touched have dead or commented out code you need to remove?
 - [ ] Do the files you touched need to have small refactors?
 - [ ] Is your PR less than 300 lines?
+
+## Basic Git Commands
+
+- **```git status```** - show modified files in working directory   
+- **```git add [-A] [file]```** - add a file to next commit (aka stage)  
+  &emsp;&minus;&nbsp; optional **```-A```** adds all modified files
+- **```git restore --staged [file]```** - unstage a file so it is not included in commit  
+- **```git commit -m "[commit message]"```** - commit staged content  
+  
+- **```git branch```** - list branches, denoting current branch with *  
+- **```git checkout [-b] [branch-name]```** - switch working branch to branch-name  
+  &emsp;&minus;&nbsp; optional **```-b```** creates a new branch called branch-name
+
+- **```git push [origin] [branch-name]```** - push local commits to remote repository  
+- **```git fetch```** - fetch commits from remote repository without changing local working directory
+- **```git merge [branch-name]```** - merge branch-name into current branch
+- **```git pull```** - fetch and merge any commits from remote repository  
+- **```git log```** - show commit history for active branch  


### PR DESCRIPTION
## Summary
Added basic git commands and conventional commit standards at the end of the Pull Request document to help use git and standardize commits.
 
## Changes Made
- Changed author checklist syntax to be checkboxes instead of a long paragraph
- Added list of common git commands with their definitions
- Added standard commit message structure in a code block
- Added list of different commit types and what they're used for
 
## Tests
- Used `pnpm run dev` in the shell to see updates to prs.mdx and correct syntax

### Before:  
<img width="1087" height="306" alt="pr_before" src="https://github.com/user-attachments/assets/d9a5b153-d12d-4bf6-8f93-bb838d861ce0" />  

### After:  
<img width="1088" height="396" alt="pr_after" src="https://github.com/user-attachments/assets/83adc4e8-b7e4-4eda-b1a7-8ab49692ebb0" />

<img width="968" height="745" alt="basic_git_commands" src="https://github.com/user-attachments/assets/5fda4fae-c72b-4b44-a67e-64443256c261" />
<img width="1007" height="885" alt="conventional_commits" src="https://github.com/user-attachments/assets/7b915e1f-efbb-477d-b115-70b45cb65200" />